### PR TITLE
Update Cluster Version

### DIFF
--- a/env
+++ b/env
@@ -12,7 +12,7 @@
     export ISTIO_VERSION=1.3.2
     export KUBECTX_VERSION=v0.7.0
     export HELM_VERSION=v2.14.3
-    export CLUSTER_VERSION=1.14.7-gke.14
+    export CLUSTER_VERSION=1.14.8-gke.12
     export KOPS_VERSION=1.12.3
 
 


### PR DESCRIPTION
Updating cluster version without which the provision gke script fails with an error 
"ERROR: (gcloud.beta.container.clusters.create) ResponseError: code=400, message=Master version "1.14.7-gke.14" is unsupported"